### PR TITLE
Fix results file path

### DIFF
--- a/C++/mie creazioni/Problem-119/Problem-119/main.cpp
+++ b/C++/mie creazioni/Problem-119/Problem-119/main.cpp
@@ -53,9 +53,14 @@ operator<<( std::ostream& dest, __int128_t value )
 
 
 int main(int argc, const char * argv[]) {
-   
+
+    const char* output_path = "Resaults.txt";           // default output file
+    if (argc > 1) {
+        output_path = argv[1];
+    }
+
     ofstream output;
-    output.open("/Users/simonecimolato/Desktop/Resaults.txt");      //this is my desktop, change this path to wherever you want to save the resaults.txt file
+    output.open(output_path);      // path supplied via command-line or defaults to ./Resaults.txt
     
     if (output.fail()) {
         cout<<"An error occurred while opening the output file "<<endl;

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # all_c
 all the c/c++ programs i ever coded
+
+## Problem-119
+
+The `Problem-119` program prints results to a text file. By default, the
+output file is `Resaults.txt` in the current directory. You can optionally
+specify a different output file path as the first command-line argument:
+
+```bash
+./Problem-119 my_output.txt
+```
+


### PR DESCRIPTION
## Summary
- let `Problem-119` accept an optional output filename argument
- document configurable output path in README

## Testing
- `g++ "C++/mie creazioni/Problem-119/Problem-119/main.cpp" -o /tmp/problem119.out`
- `/tmp/problem119.out`
- `/tmp/problem119.out /tmp/custom_results.txt`


------
https://chatgpt.com/codex/tasks/task_e_683f6839850483218d6a1b136c063d7c